### PR TITLE
fix user option example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For adding or updating data (and deleting or creating new data files) you must s
 
 ```js
 const options = {
- username:"yourUsername",
+ user:"yourUsername",
  token:"yourSecretToken"
 };
 


### PR DESCRIPTION
Hi 👋  

The option name is `user`, not `username`. The rest of the docs use this correctly, but I copied the example and got confused why gitrows was internally hitting the wrong codepaths when the option was set.