### PR TITLE
fix wrong path separator

### DIFF
--- a/lib/gitpath.js
+++ b/lib/gitpath.js
@@ -46,7 +46,7 @@ const GitPath = {
     let data = GitPath._parseUrl(url);
 
     if (!GitPath.isValid(data)) return null;
-    data.branch = data.branch && data.branch != 'master' ? ':' + data.branch : '';
+    data.branch = data.branch && data.branch != 'master' ? '#' + data.branch : '';
     return `@${data.ns}/${data.owner}/${data.repo}${data.branch}/${data.path}`;
   },
   toUrl: (path, raw = false) => {


### PR DESCRIPTION
I had the issue that I was unable to load data from a private GitHub repository, I always just got `null`. 

After some digging, I found the issue to show itself in `GitPath._parsePath`, which wasn't able to extract a valid path from the path previously produced by `GitPath.fromUrl`. The regex is expecting a `#` as the separator.

![image](https://github.com/gitrows/gitrows/assets/2625584/04e443e6-4163-44b2-a8ab-2146e52dc825)

With this change it works just like I would've expected and is very much able to load my data :)